### PR TITLE
add allow_equivalent option to belongs_to and index specs 

### DIFF
--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -113,6 +113,7 @@ module HoboFields
       index_options = {}
       index_options[:name]   = options.delete(:index) if options.has_key?(:index)
       index_options[:unique] = options.delete(:unique) if options.has_key?(:unique)
+      index_options[:allow_equivalent] = options.delete(:allow_equivalent) if options.has_key?(:allow_equivalent)
 
       fk_options = options.dup
       fk_options[:constraint_name] = options.delete(:constraint) if options.has_key?(:constraint)

--- a/lib/hobo_fields/model/index_spec.rb
+++ b/lib/hobo_fields/model/index_spec.rb
@@ -12,7 +12,7 @@ module HoboFields
         @model = model
         self.table = options.delete(:table_name) || model.table_name
         self.fields = Array.wrap(fields).*.to_s
-        self.explicit_name = options[:name]
+        self.explicit_name = options[:name] unless options.delete(:allow_equivalent)
         self.name = options.delete(:name) || model.connection.index_name(self.table, :column => self.fields).gsub(/index.*_on_/, 'on_')
         self.unique = options.delete(:unique) || name == PRIMARY_KEY_NAME
       end


### PR DESCRIPTION
This prevents warehouse index thrash if the indexes have the same value, but different names.

@aschreifels  - Pull request 1 of 2.
