### PR TITLE
Rails4.2 fix habtm and default

### DIFF
--- a/lib/generators/hobo/migration/migrator.rb
+++ b/lib/generators/hobo/migration/migrator.rb
@@ -151,7 +151,7 @@ module Generators
         def models_and_tables
           ignore_model_names = Migrator.ignore_models.*.to_s.*.underscore
           all_models = table_model_classes
-          hobo_models = all_models.select { |m| m.try.include_in_migration && m.name.underscore.not_in?(ignore_model_names) }
+          hobo_models = all_models.select { |m| (m.name['HABTM_'] || m.try.include_in_migration) && m.name.underscore.not_in?(ignore_model_names) }
           non_hobo_models = all_models - hobo_models
           db_tables = connection.tables - Migrator.ignore_tables.*.to_s - non_hobo_models.*.table_name
           [hobo_models, db_tables]

--- a/lib/hobo_fields/model/field_spec.rb
+++ b/lib/hobo_fields/model/field_spec.rb
@@ -106,16 +106,8 @@ module HoboFields
             check_attributes -= [:default] if sql_type == :text && col_spec.class.name =~ /mysql/i
             check_attributes << :limit if sql_type.in?([:string, :text, :binary, :varbinary, :integer, :enum])
             check_attributes.any? do |k|
-              if k==:default && sql_type==:datetime
-                col_spec.default.try.to_datetime != default.try.to_datetime
-              elsif k==:default && sql_type==:boolean
-                value_to_check = col_spec.default.to_s
-                if value_to_check == 'f'
-                  value_to_check = 'false'
-                elsif value_to_check == 't'
-                  value_to_check = 'true'
-                end
-                value_to_check != default.to_s # database stores false as "false"
+              if k == :default
+                col_spec.type_cast_from_database(col_spec.default) != col_spec.type_cast_from_database(default)
               else
                 col_value = col_spec.send(k)
                 if col_value.nil?


### PR DESCRIPTION
@caitlinrhd
Rails 4.2 has a new style of pseudo-classes generated for HABTM "models".
Also, 4.2 broke `Column#default` because it no longer normalizes the value from the DB to Ruby; you need to call `type_cast_from_database`. Using that method on both sides of the equality check actually removed a bunch of special cases from the code. :)
