### PR TITLE
TECH-4192: respect foreign_type option with polymorphic belongs_to

### DIFF
--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -136,8 +136,9 @@ module HoboFields
       fkey = refl.foreign_key
       declare_field(fkey.to_sym, :integer, column_options)
       if refl.options[:polymorphic]
-        declare_polymorphic_type_field(name, column_options)
-        index(["#{name}_type", fkey], index_options) if index_options[:name]!=false
+        foreign_type = options[:foreign_type] || "#{name}_type"
+        declare_polymorphic_type_field(foreign_type, column_options)
+        index([foreign_type, fkey], index_options) if index_options[:name]!=false
       else
         index(fkey, index_options) if index_options[:name]!=false
         options[:constraint_name] = options
@@ -152,9 +153,8 @@ module HoboFields
 
     # Declares the "foo_type" field that accompanies the "foo_id"
     # field for a polyorphic belongs_to
-    def self.declare_polymorphic_type_field(name, column_options)
-      type_col = "#{name}_type"
-      declare_field(type_col, :string, column_options.merge(:limit => 255))
+    def self.declare_polymorphic_type_field(foreign_type, column_options)
+      declare_field(foreign_type, :string, column_options.merge(:limit => 255))
       # FIXME: Before hobo_fields was extracted, this used to now do:
       # never_show(type_col)
       # That needs doing somewhere


### PR DESCRIPTION
We are renaming a polymorphic belongs_to association as part of TECH-4192. To avoid changes to the DB, we want to specify the `foreign_type` option.

These changes update HoboFields to respect the `foreign_type` option when declaring the _type_ column and index.

For example, consider renaming an `owner` association to `manager`
_...from this:_

```ruby
belongs_to :owner,
           polymorphic: true
```
_to this:_
```ruby
belongs_to :manager,
           polymorphic: true,
           foreign_key: "owner_id",
           foreign_type: "owner_type"
```

Without the changes in this PR, running `rails generate hobo:migration -gnpdq` generates:

```

---------- Up Migration ----------
add_column :offices, :manager_type, :string
remove_column :offices, :owner_type

remove_index :offices, :name => :owner_type_and_id rescue ActiveRecord::StatementInvalid
add_index :offices, [:manager_type, :manager_id], :name => 'manager_type_and_id'
----------------------------------

---------- Down Migration --------
remove_column :offices, :manager_type
add_column :offices, :owner_type, :string, limit: 255

remove_index :offices, :name => :manager_type_and_id rescue ActiveRecord::StatementInvalid
add_index :offices, [:owner_type, :owner_id], :name => 'owner_type_and_id'
----------------------------------
```

With the changes in this PR, hobo will not generate a migration.