### PR TITLE
Passion validations in field spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gemspec
 group :testapp do
   gem 'bootsnap',     '>= 1.1.0', require: false
   gem 'listen'
-  gem 'kramdown'
-  gem 'RedCloth'
 end
 
 gem 'appraisal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hobo_fields (3.1.0)
+    hobo_fields (2.99.0)
       invoca-utils (~> 0.4)
       rails (>= 4.2, < 7)
 
@@ -9,7 +9,6 @@ GEM
   remote: https://rubygems.org/
   remote: https://gem.fury.io/invoca/
   specs:
-    RedCloth (4.3.2)
     actioncable (5.2.4.3)
       actionpack (= 5.2.4.3)
       nio4r (~> 2.0)
@@ -70,8 +69,6 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     invoca-utils (0.4.1)
-    kramdown (2.3.0)
-      rexml
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -131,7 +128,6 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
-    rexml (3.2.4)
     rubydoctest (1.1.5)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -155,11 +151,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  RedCloth
   appraisal
   bootsnap (>= 1.1.0)
   hobo_fields!
-  kramdown
   listen
   pry
   pry-byebug

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ require 'rake_test_warning_false'
 
 require 'rubygems'
 require 'tmpdir'
-require 'kramdown'
 require 'pry'
 
 include Rake::DSL

--- a/lib/hobo_fields/extensions/active_record/fields_declaration.rb
+++ b/lib/hobo_fields/extensions/active_record/fields_declaration.rb
@@ -20,12 +20,6 @@ module HoboField
         else
           dsl.instance_eval(&b)
         end
-
-        field_specs.each do |field_name, field_spec|
-          if (validates_options = field_spec.options[:validates])
-            validates field_name, validates_options
-          end
-        end
       end
     end
   end

--- a/lib/hobo_fields/extensions/active_record/fields_declaration.rb
+++ b/lib/hobo_fields/extensions/active_record/fields_declaration.rb
@@ -20,6 +20,13 @@ module HoboField
         else
           dsl.instance_eval(&b)
         end
+
+        field_specs.each do |field_name, field_spec|
+          if (validates_options = field_spec.options[:validates])
+            puts "validates #{field_name}, #{validates_options}"
+            validates field_name, validates_options
+          end
+        end
       end
     end
   end

--- a/lib/hobo_fields/extensions/active_record/fields_declaration.rb
+++ b/lib/hobo_fields/extensions/active_record/fields_declaration.rb
@@ -23,7 +23,6 @@ module HoboField
 
         field_specs.each do |field_name, field_spec|
           if (validates_options = field_spec.options[:validates])
-            puts "validates #{field_name}, #{validates_options}"
             validates field_name, validates_options
           end
         end

--- a/lib/hobo_fields/field_declaration_dsl.rb
+++ b/lib/hobo_fields/field_declaration_dsl.rb
@@ -3,7 +3,9 @@
 require 'active_support/proxy_object'
 
 module HoboFields
-  class FieldDeclarationDsl
+  class FieldDeclarationDsl < BasicObject # avoid Object because that gets extended by lots of gems
+    include ::Kernel                      # but we need the basic class methods
+
     instance_methods.each do |m|
       unless m.to_s.starts_with?('__') || m.in?([:object_id, :instance_eval])
         undef_method(m)

--- a/lib/hobo_fields/field_declaration_dsl.rb
+++ b/lib/hobo_fields/field_declaration_dsl.rb
@@ -3,8 +3,12 @@
 require 'active_support/proxy_object'
 
 module HoboFields
-
-  class FieldDeclarationDsl < ActiveSupport::ProxyObject
+  class FieldDeclarationDsl
+    instance_methods.each do |m|
+      unless m.to_s.starts_with?('__') || m.in?([:object_id, :instance_eval])
+        undef_method(m)
+      end
+    end
 
     def initialize(model, options = {})
       @model = model

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -215,6 +215,10 @@ module HoboFields
         validates_presence_of   name if :required.in?(args)
         validates_uniqueness_of name, allow_nil: !:required.in?(args) if :unique.in?(args)
 
+        if (validates_options = args[:validates])
+          validates field_name, validates_options
+        end
+
         # Support for custom validations in Hobo Fields
         if (type_class = HoboFields.to_class(type))
           if type_class.public_method_defined?("validate")

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -282,8 +282,7 @@ module HoboFields
       def column(name)
         defined?(@table_exists) or @table_exists = table_exists?
         if @table_exists
-          name = name.to_s
-          columns.find { |c| c.name == name }
+          columns_hash[name.to_s]
         end
       end
     end

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -50,7 +50,8 @@ module HoboFields
     module ClassMethods
       def index(fields, options = {})
         # don't double-index fields
-        unless index_specs.*.fields.include?(Array.wrap(fields).*.to_s)
+        index_fields_s = Array.wrap(fields).*.to_s
+        unless index_specs.any? { |index_spec| index_spec.fields == index_fields_s }
           index_specs << HoboFields::Model::IndexSpec.new(self, fields, options)
         end
       end
@@ -60,8 +61,9 @@ module HoboFields
       end
 
       def constraint(fkey, options={})
-        unless constraint_specs.*.foreign_key.include?(fkey.to_s)
-          constraint_specs << HoboFields::Model::ForeignKeySpec.new(self, fkey, options )
+        fkey_s = fkey.to_s
+        unless constraint_specs.any? { |constraint_spec| constraint_spec.foreign_key == fkey_s }
+          constraint_specs << HoboFields::Model::ForeignKeySpec.new(self, fkey, options)
         end
       end
 

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -83,7 +83,7 @@ module HoboFields
         end
         field_added(name, type, args, options) if respond_to?(:field_added)
         add_formatting_for_field(name, type, args)
-        add_validations_for_field(name, type, args)
+        add_validations_for_field(name, type, args, options)
         add_index_for_field(name, args, options)
         declare_attr_type(name, type, options) unless HoboFields.plain_type?(type)
         field_specs[name] = HoboFields::Model::FieldSpec.new(self, name, type, options)
@@ -211,12 +211,12 @@ module HoboFields
 
       # Add field validations according to arguments in the
       # field declaration
-      def add_validations_for_field(name, type, args)
+      def add_validations_for_field(name, type, args, options)
         validates_presence_of   name if :required.in?(args)
         validates_uniqueness_of name, allow_nil: !:required.in?(args) if :unique.in?(args)
 
-        if (validates_options = args[:validates])
-          validates field_name, validates_options
+        if (validates_options = options[:validates])
+          validates name, validates_options
         end
 
         # Support for custom validations in Hobo Fields

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -182,9 +182,9 @@ module HoboFields
           if refl.options[:polymorphic]
             foreign_type = options[:foreign_type] || "#{name}_type"
             declare_polymorphic_type_field(foreign_type, column_options)
-            index([foreign_type, fkey], index_options) if index_options[:name]!=false
+            index([foreign_type, fkey], index_options) if index_options[:name] != false
           else
-            index(fkey, index_options) if index_options[:name]!=false
+            index(fkey, index_options) if index_options[:name] != false
             options[:constraint_name] = options
             constraint(fkey, fk_options) if fk_options[:constraint_name] != false
           end

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -6,7 +6,7 @@ module HoboFields
   module Model
     class << self
       def mix_in(base)
-        base.singleton_class.prepend ClassMethods
+        base.singleton_class.prepend ClassMethods unless base.singleton_class < ClassMethods # don't mix in if a base class already did it
 
         base.class_eval do
           # ignore the model in the migration until somebody sets

--- a/lib/hobo_fields/model/field_spec.rb
+++ b/lib/hobo_fields/model/field_spec.rb
@@ -54,7 +54,7 @@ module HoboFields
       end
 
       def sql_options
-        @options.except(:ruby_default)
+        @options.except(:ruby_default, :validates)
       end
 
       def limit

--- a/lib/hobo_fields/version.rb
+++ b/lib/hobo_fields/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HoboFields
-  VERSION = "3.1.0"
+  VERSION = "2.99.0"
 end

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -643,6 +643,21 @@ HoboFields has some support for legacy keys.
     >> ActiveRecord::Base.connection.execute "drop table `adverts`;"
 {.hidden}
 
+## DSL
+
+The DSL allows lambdas and constants
+
+    >>
+        class User < ActiveRecord::Base
+          fields do
+            company :string, limit: 255, ruby_default: lambda { Hash.name }
+          end
+        end
+    >> User.field_specs.keys
+    => ['company']
+    >> User.field_specs['company'].options[:ruby_default]&.call
+    => "Hash"
+
 
 ## validates
 

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -648,14 +648,23 @@ HoboFields has some support for legacy keys.
 
 HoboFields can accept a validates hash in the field options.
 
+    >> $company_validates_options = :none
+    >>
+       class Ad < ActiveRecord::Base; end;
+       def Ad.validates(field_name, options)
+         $company_validates_options = "got field_name: #{field_name}, options: #{options.inspect}"
+       end
     >>
       class Ad < ActiveRecord::Base
         fields do
-          name :string, limit: 255, index: true, unique: true, validates: { presence: true, :uniqueness => { case_sensitive: false } }
+          company :string, limit: 255, index: true, unique: true, validates: { presence: true, :uniqueness => { case_sensitive: false } }
         end
         self.primary_key="advert_id"
       end
+    >> # expect(Ad).to receive(:validates).with(:company, presence: true, uniqueness: { case_sensitive: false })
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> ActiveRecord::Migration.class_eval up
-    >> Ad.field_specs['name'].options[:validates].inspect
+    >> $company_validates_options
+    => "got field_name: company, options: {:presence=>true, :uniqueness=>{:case_sensitive=>false}}"
+    >> Ad.field_specs['company'].options[:validates].inspect
     => "{:presence=>true, :uniqueness=>{:case_sensitive=>false}}"

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -642,3 +642,20 @@ HoboFields has some support for legacy keys.
     >> nuke_model_class(Ad)
     >> ActiveRecord::Base.connection.execute "drop table `adverts`;"
 {.hidden}
+
+
+## validates
+
+HoboFields can accept a validates hash in the field options.
+
+    >>
+      class Ad < ActiveRecord::Base
+        fields do
+          name :string, limit: 255, index: true, unique: true, validates: { presence: true, :uniqueness => { case_sensitive: false } }
+        end
+        self.primary_key="advert_id"
+      end
+    >> up, down = Generators::Hobo::Migration::Migrator.run
+    >> ActiveRecord::Migration.class_eval up
+    >> Ad.field_specs['name'].options[:validates].inspect
+    => "{:presence=>true, :uniqueness=>{:case_sensitive=>false}}"


### PR DESCRIPTION
- Adds `validates:` option to field spec (`declare_field` or a declaration line inside `fields do`). These are passed to the `ActiveRecord::Base.validates` method.

Cool thing about this branch and the corresponding one in `web`: getting them green chased out several bugs that we would have had to track down in the Rails 5 project. Now we don't!