### PR TITLE
Tech 4682: remove text field multiply by UTF8_BYTES_PER_CHAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - Unreleased
+### Changed
+- Removed automatic scaling of `:text :limit` by UTF8_BYTES_PER_CHAR = 3.
+
+### Added
+- When using MySQL, `:text :limit` is now rounded up to nearest supported size, with a default of the max (LONGTEXT) size, 0xffffffff.
+For other databases, `:text :limit` is ignored.
+
+
 ## [3.1.0] - 2020-07-21
 ### Added
 - Added support for Rails 6
@@ -14,4 +23,5 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Removed
 - Removed support for rich type classes like `Markdown` and `HTML` text fields
 
+[3.2.0]: https://github.com/Invoca/hobo_fields/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/Invoca/pnapi_models/tree/v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.0] - Unreleased
+## [4.0.0] - Unreleased
 ### Changed
-- Removed automatic scaling of `:text :limit` by UTF8_BYTES_PER_CHAR = 3.
+- Removed automatic scaling of `:text :limit` by / UTF8_BYTES_PER_CHAR = 3.
 
 ### Added
-- When using MySQL, `:text :limit` is now rounded up to nearest supported size, with a default of the max (LONGTEXT) size, 0xffffffff.
+- When using MySQL, `:text :limit` is now rounded up to nearest supported size, with a default of the max (LONGTEXT) size, `0xffff_ffff`.
 For other databases, `:text :limit` is ignored.
 
 
@@ -23,5 +23,5 @@ For other databases, `:text :limit` is ignored.
 ### Removed
 - Removed support for rich type classes like `Markdown` and `HTML` text fields
 
-[3.2.0]: https://github.com/Invoca/hobo_fields/compare/v3.1.0...v3.2.0
+[4.0.0]: https://github.com/Invoca/hobo_fields/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/Invoca/pnapi_models/tree/v3.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hobo_fields (4.0.0.pre.1)
+    hobo_fields (4.0.0.pre.2)
       invoca-utils (~> 0.4)
       rails (>= 4.2, < 7)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hobo_fields (3.2.0.pre.1)
+    hobo_fields (3.2.0.pre.2)
       invoca-utils (~> 0.4)
       rails (>= 4.2, < 7)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hobo_fields (3.2.0.pre.2)
+    hobo_fields (4.0.0.pre.1)
       invoca-utils (~> 0.4)
       rails (>= 4.2, < 7)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hobo_fields (3.1.0)
+    hobo_fields (3.2.0.pre.1)
       invoca-utils (~> 0.4)
       rails (>= 4.2, < 7)
 

--- a/lib/generators/hobo/migration/migrator.rb
+++ b/lib/generators/hobo/migration/migrator.rb
@@ -163,7 +163,6 @@ module Generators
           [hobo_models, db_tables]
         end
 
-
         # return a hash of table renames and modifies the passed arrays so
         # that renamed tables are no longer listed as to_create or to_drop
         def extract_table_renames!(to_create, to_drop)
@@ -394,7 +393,8 @@ module Generators
             spec = model.field_specs[c]
             if spec.different_to?(col) # TODO: DRY this up to a diff function that returns the differences. It's different if it has differences. -Colin
               change_spec = fk_field_options(model, c)
-              change_spec[:limit]     = spec.limit     if HoboFields::Model::FieldSpec::mysql_text_limits? &&
+              change_spec[:limit]     = spec.limit     if (spec.sql_type != :text ||
+                                                         HoboFields::Model::FieldSpec::mysql_text_limits?) &&
                                                          (spec.limit || col.limit)
               change_spec[:precision] = spec.precision unless spec.precision.nil?
               change_spec[:scale]     = spec.scale     unless spec.scale.nil?

--- a/lib/generators/hobo/migration/migrator.rb
+++ b/lib/generators/hobo/migration/migrator.rb
@@ -152,14 +152,14 @@ module Generators
         # Returns an array of model classes and an array of table names
         # that generation needs to take into account
         def models_and_tables
-          ignore_model_names = Migrator.ignore_models.*.to_s.*.underscore
+          ignore_model_names = Migrator.ignore_models.map { | model| model.to_s.underscore }
           all_models = table_model_classes
           hobo_models = all_models.select do |m|
             (m.name['HABTM_'] ||
               (m.include_in_migration if m.respond_to?(:include_in_migration))) && !m.name.underscore.in?(ignore_model_names)
           end
           non_hobo_models = all_models - hobo_models
-          db_tables = connection.tables - Migrator.ignore_tables.*.to_s - non_hobo_models.*.table_name
+          db_tables = connection.tables - Migrator.ignore_tables.map(&:to_s) - non_hobo_models.map(&:table_name)
           [hobo_models, db_tables]
         end
 

--- a/lib/generators/hobo/migration/migrator.rb
+++ b/lib/generators/hobo/migration/migrator.rb
@@ -35,7 +35,7 @@ module Generators
           i = 0
           foreign_keys.inject({}) do |h, v|
             # some trickery to avoid an infinite loop when FieldSpec#initialize tries to call model.field_specs
-            h[v] = HoboFields::Model::FieldSpec.new(self, v, :integer, :position => i, :null => false)
+            h[v] = HoboFields::Model::FieldSpec.new(self, v, :integer, position: i, null: false)
             i += 1
             h
           end
@@ -460,7 +460,7 @@ module Generators
         def drop_index(table, name)
           # see https://hobo.lighthouseapp.com/projects/8324/tickets/566
           # for why the rescue exists
-          "remove_index :#{table}, :name => :#{name} rescue ActiveRecord::StatementInvalid"
+          "remove_index :#{table}, name: :#{name} rescue ActiveRecord::StatementInvalid"
         end
 
         def change_foreign_key_constraints(model, old_table_name)
@@ -502,7 +502,11 @@ module Generators
             next if k == :limit && type == :text &&
               (!HoboFields::Model::FieldSpec::mysql_text_limits? || v == HoboFields::Model::FieldSpec::MYSQL_LONGTEXT_LIMIT)
 
-            "#{k.inspect} => #{v.inspect}"
+            if k.is_a?(Symbol)
+              "#{k}: #{v.inspect}"
+            else
+              "#{k.inspect} => #{v.inspect}"
+            end
           end.compact
         end
 

--- a/lib/generators/hobo/support/model.rb
+++ b/lib/generators/hobo/support/model.rb
@@ -35,7 +35,7 @@ module Hobo
           end
 
           def max_attribute_length
-            attributes.*.name.*.length.max
+            attributes.map { |attribute| attribute.name.length }.max
           end
 
           def field_attributes
@@ -43,15 +43,15 @@ module Hobo
           end
 
           def accessible_attributes
-            field_attributes.*.name + bts.map {|bt| "#{bt}_id"} + bts + hms
+            field_attributes.map(&:name) + bts.map {|bt| "#{bt}_id"} + bts + hms
           end
 
           def hms
-            attributes.select { |a| a.name == "hm" }.*.type
+            attributes.select { |a| a.name == "hm" }.map(&:type)
           end
 
           def bts
-            attributes.select { |a| a.name == "bt" }.*.type
+            attributes.select { |a| a.name == "bt" }.map(&:type)
           end
         end
       end

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -50,7 +50,7 @@ module HoboFields
     module ClassMethods
       def index(fields, options = {})
         # don't double-index fields
-        index_fields_s = Array.wrap(fields).*.to_s
+        index_fields_s = Array.wrap(fields).map(&:to_s)
         unless index_specs.any? { |index_spec| index_spec.fields == index_fields_s }
           index_specs << HoboFields::Model::IndexSpec.new(self, fields, options)
         end

--- a/lib/hobo_fields/model.rb
+++ b/lib/hobo_fields/model.rb
@@ -79,10 +79,6 @@ module HoboFields
       # declarations.
       def declare_field(name, type, *args)
         options = args.extract_options!
-        if type == :text
-          options[:limit] or raise ArgumentError, ":text field must have :limit: #{self.name}##{name}: #{options.inspect}"
-          options[:char_limit] = options.delete(:limit)
-        end
         field_added(name, type, args, options) if respond_to?(:field_added)
         add_formatting_for_field(name, type, args)
         add_validations_for_field(name, type, args, options)

--- a/lib/hobo_fields/model/field_spec.rb
+++ b/lib/hobo_fields/model/field_spec.rb
@@ -5,10 +5,10 @@ module HoboFields
     class FieldSpec
       class UnknownSqlTypeError < RuntimeError; end
 
-      MYSQL_TINYTEXT_LIMIT    = 0xff
-      MYSQL_TEXT_LIMIT        = 0xff_ff
-      MYSQL_MEDIUMTEXT_LIMIT  = 0xff_ff_ff
-      MYSQL_LONGTEXT_LIMIT    = 0xff_ff_ff_ff
+      MYSQL_TINYTEXT_LIMIT    =        0xff
+      MYSQL_TEXT_LIMIT        =      0xffff
+      MYSQL_MEDIUMTEXT_LIMIT  =   0xff_ffff
+      MYSQL_LONGTEXT_LIMIT    = 0xffff_ffff
 
       class << self
         # method for easy stubbing in tests

--- a/lib/hobo_fields/model/field_spec.rb
+++ b/lib/hobo_fields/model/field_spec.rb
@@ -10,6 +10,8 @@ module HoboFields
       MYSQL_MEDIUMTEXT_LIMIT  =   0xff_ffff
       MYSQL_LONGTEXT_LIMIT    = 0xffff_ffff
 
+      MYSQL_TEXT_LIMITS_ASCENDING = [MYSQL_TINYTEXT_LIMIT, MYSQL_TEXT_LIMIT, MYSQL_MEDIUMTEXT_LIMIT, MYSQL_LONGTEXT_LIMIT].freeze
+
       class << self
         # method for easy stubbing in tests
         def mysql_text_limits?
@@ -21,11 +23,11 @@ module HoboFields
         end
 
         def round_up_mysql_text_limit(limit)
-          [MYSQL_TINYTEXT_LIMIT, MYSQL_TEXT_LIMIT, MYSQL_MEDIUMTEXT_LIMIT].find do |mysql_supported_text_limit|
+          MYSQL_TEXT_LIMITS_ASCENDING.find do |mysql_supported_text_limit|
             if limit <= mysql_supported_text_limit
               mysql_supported_text_limit
             end
-          end || MYSQL_LONGTEXT_LIMIT
+          end or raise ArgumentError, "limit of #{limit} is too large for MySQL"
         end
       end
 

--- a/lib/hobo_fields/model/index_spec.rb
+++ b/lib/hobo_fields/model/index_spec.rb
@@ -53,25 +53,15 @@ module HoboFields
         name == PRIMARY_KEY_NAME
       end
 
-      def default_name?
-        name == @model.connection.index_name(table, column: fields)
-      end
-
       def to_add_statement(new_table_name, existing_primary_key = nil)
         if primary_key? && !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
           to_add_primary_key_statement(new_table_name, existing_primary_key)
         else
-          r = +"add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
-          r << ", unique: true" if unique
-          r << ", where: '#{self.where}'" if self.where.present?
-          if default_name?
-            check_name = @model.connection.index_name(self.table, column: self.fields)
-          else
-            r = +"add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
-            r << ", unique: true" if unique
-            r << ", name: '#{name}'"
-            r
-          end
+          r = +"add_index #{new_table_name.to_sym.inspect}, #{fields.map(&:to_sym).inspect}"
+          r += ", unique: true"      if unique
+          r += ", where: '#{where}'" if where.present?
+          r += ", name: '#{name}'"
+          r
         end
       end
 

--- a/lib/hobo_fields/model/index_spec.rb
+++ b/lib/hobo_fields/model/index_spec.rb
@@ -15,7 +15,7 @@ module HoboFields
       def initialize(model, fields, options={})
         @model = model
         self.table = options.delete(:table_name) || model.table_name
-        self.fields = Array.wrap(fields).*.to_s
+        self.fields = Array.wrap(fields).map(&:to_s)
         self.explicit_name = options[:name] unless options.delete(:allow_equivalent)
         self.name = options.delete(:name) || model.connection.index_name(self.table, :column => self.fields).gsub(/index.*_on_/, 'on_')
         self.unique = options.delete(:unique) || name == PRIMARY_KEY_NAME || false
@@ -61,13 +61,13 @@ module HoboFields
         if primary_key? && !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
           to_add_primary_key_statement(new_table_name, existing_primary_key)
         else
-          r = "add_index :#{new_table_name}, #{fields.*.to_sym.inspect}"
+          r = "add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
           r += ", :unique => true" if unique
           r += ", :where => '#{self.where}'" if self.where.present?
           if default_name?
             check_name = @model.connection.index_name(self.table, :column => self.fields)
           else
-            r = "add_index :#{new_table_name}, #{fields.*.to_sym.inspect}"
+            r = "add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
             r += ", :unique => true" if unique
             r += ", :name => '#{name}'"
             r

--- a/lib/hobo_fields/model/index_spec.rb
+++ b/lib/hobo_fields/model/index_spec.rb
@@ -33,6 +33,7 @@ module HoboFields
       def self.for_model(model, old_table_name=nil)
         t = old_table_name || model.table_name
         connection = model.connection.dup
+        # TODO: Change below to use prepend
         class << connection              # defeat Rails code that skips the primary keys by changing their name to PRIMARY_KEY_NAME
           def each_hash(result)
             super do |hash|

--- a/lib/hobo_fields/model/index_spec.rb
+++ b/lib/hobo_fields/model/index_spec.rb
@@ -17,7 +17,7 @@ module HoboFields
         self.table = options.delete(:table_name) || model.table_name
         self.fields = Array.wrap(fields).map(&:to_s)
         self.explicit_name = options[:name] unless options.delete(:allow_equivalent)
-        self.name = options.delete(:name) || model.connection.index_name(self.table, :column => self.fields).gsub(/index.*_on_/, 'on_')
+        self.name = options.delete(:name) || model.connection.index_name(self.table, column: self.fields).gsub(/index.*_on_/, 'on_')
         self.unique = options.delete(:unique) || name == PRIMARY_KEY_NAME || false
 
         if self.name.length > MYSQL_INDEX_NAME_MAX_LENGTH
@@ -45,7 +45,7 @@ module HoboFields
           end
         end
         connection.indexes(t).map do |i|
-          self.new(model, i.columns, :name => i.name, :unique => i.unique, :where => i.where, :table_name => old_table_name) unless model.ignore_indexes.include?(i.name)
+          self.new(model, i.columns, name: i.name, unique: i.unique, where: i.where, table_name: old_table_name) unless model.ignore_indexes.include?(i.name)
         end.compact
       end
 
@@ -54,22 +54,22 @@ module HoboFields
       end
 
       def default_name?
-        name == @model.connection.index_name(table, :column => fields)
+        name == @model.connection.index_name(table, column: fields)
       end
 
       def to_add_statement(new_table_name, existing_primary_key = nil)
         if primary_key? && !ActiveRecord::Base.connection.class.name.match?(/SQLite3Adapter/)
           to_add_primary_key_statement(new_table_name, existing_primary_key)
         else
-          r = "add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
-          r += ", :unique => true" if unique
-          r += ", :where => '#{self.where}'" if self.where.present?
+          r = +"add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
+          r << ", unique: true" if unique
+          r << ", where: '#{self.where}'" if self.where.present?
           if default_name?
-            check_name = @model.connection.index_name(self.table, :column => self.fields)
+            check_name = @model.connection.index_name(self.table, column: self.fields)
           else
-            r = "add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
-            r += ", :unique => true" if unique
-            r += ", :name => '#{name}'"
+            r = +"add_index :#{new_table_name}, #{fields.map(&:to_sym).inspect}"
+            r << ", unique: true" if unique
+            r << ", name: '#{name}'"
             r
           end
         end
@@ -122,7 +122,7 @@ module HoboFields
         @child_table = model.table_name #unless a table rename, which would happen when a class is renamed??
         @parent_table_name = options[:parent_table]
         @foreign_key_name = options[:foreign_key] || self.foreign_key
-        @index_name = options[:index_name] || model.connection.index_name(model.table_name, :column => foreign_key)
+        @index_name = options[:index_name] || model.connection.index_name(model.table_name, column: foreign_key)
         @constraint_name = options[:constraint_name] || @index_name || ''
         @on_delete_cascade = options[:dependent] == :delete
 

--- a/lib/hobo_fields/model/index_spec.rb
+++ b/lib/hobo_fields/model/index_spec.rb
@@ -24,9 +24,8 @@ module HoboFields
           raise IndexNameTooLongError, "Index '#{self.name}' exceeds MySQL limit of #{MYSQL_INDEX_NAME_MAX_LENGTH} characters. Give it a shorter name."
         end
 
-        if options[:where]
-          self.where = "#{options.delete(:where)}"
-          self.where = "(#{self.where})" unless self.where.start_with?('(')
+        if (where = options[:where])
+          self.where = where.start_with?('(') ? where : "(#{where})"
         end
       end
 

--- a/lib/hobo_fields/version.rb
+++ b/lib/hobo_fields/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HoboFields
-  VERSION = "3.2.0.pre.1"
+  VERSION = "3.2.0.pre.2"
 end

--- a/lib/hobo_fields/version.rb
+++ b/lib/hobo_fields/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HoboFields
-  VERSION = "3.1.0"
+  VERSION = "3.2.0.pre.1"
 end

--- a/lib/hobo_fields/version.rb
+++ b/lib/hobo_fields/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HoboFields
-  VERSION = "3.2.0.pre.2"
+  VERSION = "4.0.0.pre.1"
 end

--- a/lib/hobo_fields/version.rb
+++ b/lib/hobo_fields/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HoboFields
-  VERSION = "4.0.0.pre.1"
+  VERSION = "4.0.0.pre.2"
 end

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -87,14 +87,14 @@ If we add a new field to the model, the migration generator will add it to the d
      class Advert
        fields do
          name :string, limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
          published_at :datetime, null: true
        end
      end
     >> up, down = migrate
     >> up
     =>
-     "add_column :adverts, :body, :text, limit: 0xffff
+     "add_column :adverts, :body, :text
      add_column :adverts, :published_at, :datetime"
     >> down
     =>
@@ -110,7 +110,7 @@ If we remove a field from the model, the migration generator removes the databas
      class Advert < ActiveRecord::Base
        fields do
          name :string, limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
        end
      end
     >> up, down = migrate
@@ -127,7 +127,7 @@ Here we rename the `name` field to `title`. By default the generator sees this a
      class Advert < ActiveRecord::Base
        fields do
          title :string, limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
        end
      end
     >> # Just generate - don't run the migration:
@@ -160,13 +160,13 @@ Let's apply that change to the database
     >>
      class Advert
        fields do
-         title :text, limit: 0xffff, null: true
-         body :text, limit: 0xffff, null: true
+         title :text, null: true
+         body :text, null: true
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "change_column :adverts, :title, :text, :limit => 196605"
+    => "change_column :adverts, :title, :text"
     >> down
     => "change_column :adverts, :title, :string, limit: 255"
 
@@ -177,14 +177,14 @@ Let's apply that change to the database
      class Advert
        fields do
          title :string, :default => "Untitled", limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
        end
      end
     >> up, down = migrate
     >> up.split(',').slice(0,3).join(',')
     => 'change_column :adverts, :title, :string'
     >> up.split(',').slice(3,2).sort.join(',')
-    => " :default => \"Untitled\", :limit => 255"
+    => " :default => \"Untitled\""
     >> down
     => "change_column :adverts, :title, :string, limit: 255"
 
@@ -213,10 +213,31 @@ Note that limit on a decimal column is ignored (use :scale and :precision)
     >> up
     => "add_column :adverts, :price, :decimal, :null => false"
 
+Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
+allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
+If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
+that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
+
+    >>
+     class Advert
+       fields do
+         notes :text
+         description :text, limit: 30000
+       end
+     end
+    >> up, down = Generators::Hobo::Migration::Migrator.run
+    >> up
+    => "add_column :adverts, :price, :decimal, :null => false
+        add_column :adverts, :notes, :text, :null => false
+        add_column :adverts, :description, :text, :null => false"
+
+(No limit on `add_column ... :description` above since these tests are run against SQLite.)
+
 Cleanup
 {.hidden}
 
     >> Advert.field_specs.delete :price
+    >> Advert.field_specs.delete :notes
 {.hidden}
 
 
@@ -267,7 +288,8 @@ Cleanup:
 {.hidden}
 
         >> Advert.field_specs.delete(:c_id)
-        >> Advert.index_specs.delete_if {|spec| spec.fields==["c_id"]}
+        >> Advert.field_specs.delete(:description)
+        >> Advert.index_specs.delete_if { |spec| spec.fields==["c_id"] }
 {.hidden}
 
 You can avoid generating the index by specifying `:index => false`
@@ -455,7 +477,7 @@ The migration generator respects the `set_table_name` declaration, although as b
        self.table_name="ads"
        fields do
          title :string, :default => "Untitled", limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :ads)
@@ -490,7 +512,7 @@ As with renaming columns, we have to tell the migration generator about the rena
      class Advertisement < ActiveRecord::Base
        fields do
          title :string, :default => "Untitled", limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :advertisements)
@@ -527,7 +549,7 @@ Adding a subclass or two should introduce the 'type' column and no other changes
         >>
          class Advert < ActiveRecord::Base
            fields do
-             body :text, limit: 0xffff, null: true
+             body :text, null: true
              title :string, :default => "Untitled", limit: 255, null: true
            end
          end
@@ -580,7 +602,7 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
      class Advert
        fields do
          name :string, :default => "No Name", limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => {:title => :name})
@@ -603,7 +625,7 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
      class Ad < ActiveRecord::Base
        fields do
          title      :string, :default => "Untitled", limit: 255
-         body       :text, limit: 0xffff, null: true
+         body       :text, null: true
          created_at :datetime
        end
      end
@@ -617,7 +639,7 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
     >>
      class Advert < ActiveRecord::Base
        fields do
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
          title :string, :default => "Untitled", limit: 255, null: true
        end
      end
@@ -632,7 +654,7 @@ HoboFields has some support for legacy keys.
      class Advert
        fields do
          name :string, :default => "No Name", limit: 255, null: true
-         body :text, limit: 0xffff, null: true
+         body :text, null: true
        end
        self.primary_key="advert_id"
      end

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -191,12 +191,12 @@ Let's apply that change to the database
     >>
      class Advert
        fields do
-         price :integer, :limit => 2
+         price :integer, :null => true, :limit => 2
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "add_column :adverts, :price, :integer, :null => false, :limit => 2"
+    => "add_column :adverts, :price, :integer, :limit => 2"
 
 Now run the migration, then change the limit:
 
@@ -204,14 +204,14 @@ Now run the migration, then change the limit:
     >>
      class Advert
        fields do
-         price :integer, :limit => 3
+         price :integer, :null => true, :limit => 3
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "change_column :adverts, :price, :integer, :limit => 3, :null => false"
+    => "change_column :adverts, :price, :integer, :limit => 3"
     >> down
-    => "change_column :adverts, :price, :integer, limit: 2, null: false"
+    => "change_column :adverts, :price, :integer, limit: 2"
 
 Note that limit on a decimal column is ignored (use :scale and :precision)
 
@@ -219,12 +219,12 @@ Note that limit on a decimal column is ignored (use :scale and :precision)
     >>
      class Advert
        fields do
-         price :decimal, :limit => 4
+         price :decimal, :null => true, :limit => 4
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "add_column :adverts, :price, :decimal, :null => false"
+    => "add_column :adverts, :price, :decimal"
 
 Limits are generally not needed for `text` fields, because by default, `text` fields will use the maximum size
 allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Postgres, 1 billion in Sqlite).
@@ -242,7 +242,7 @@ that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xfffff
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "add_column :adverts, :price, :decimal, :null => false
+    => "add_column :adverts, :price, :decimal
         add_column :adverts, :notes, :text, :null => false
         add_column :adverts, :description, :text, :null => false"
 

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -413,11 +413,9 @@ You can specify the index name with :index
            belongs_to :category, index: 'my_index'
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up
-        =>
-         "add_column :adverts, :category_id, :integer
-
-         add_index :adverts, [:category_id], :name => 'my_index'"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :category_id, :integer, :limit => 8, :null => false
+            add_index :adverts, [:category_id], :name => 'my_index'"
 
 Cleanup:
 {.hidden}
@@ -439,14 +437,14 @@ Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_loc
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up
-        =>
-         "add_column :adverts, :created_at, :datetime
-         add_column :adverts, :updated_at, :datetime"
-        >> down
-        =>
-         "remove_column :adverts, :created_at
-         remove_column :adverts, :updated_at"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :created_at, :datetime
+            add_column :adverts, :updated_at, :datetime
+            add_column :adverts, :lock_version, :integer, :null => false, :default => 1"
+        >> down.gsub(/\n+/, "\n")
+        => "remove_column :adverts, :created_at
+            remove_column :adverts, :updated_at
+            remove_column :adverts, :lock_version"
         >>
 
 Cleanup:
@@ -654,12 +652,11 @@ Dropping tables is where the automatic down-migration really comes in handy:
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
     => "drop_table :adverts"
-    >> down
-    =>
-     "create_table "adverts", :force => true do |t|
-       t.text   "body"
-       t.string "title", :default => "Untitled"
-     end"
+    >> down.gsub(/^  /, '__')
+    => "create_table \"adverts\", id: :integer, force: :cascade do |t|
+        __t.string \"name\", limit: 255
+        __t.index [\"id\"], name: \"PRIMARY_KEY\", unique: true
+        end"
 
 ## STI
 

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -63,7 +63,7 @@ Here we see a simple `create_table` migration along with the `drop_table` down m
 Normally we would run the generated migration with `rake db:create`. We can achieve the same effect directly in Ruby like this:
 
     >> ActiveRecord::Migration.class_eval up
-    >> Advert.columns.*.name
+    >> Advert.columns.map(&:name)
     => ["id", "name"]
 
 We'll define a method to make that easier next time

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -133,14 +133,11 @@ Here we rename the `name` field to `title`. By default the generator sees this a
     >> # Just generate - don't run the migration:
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    =>
-     "add_column :adverts, :title, :string
-     remove_column :adverts, :name"
+    => "add_column :adverts, :title, :string, :limit => 255
+        remove_column :adverts, :name"
     >> down
-    =>""
-    remove_column :adverts, :title
-    add_column :adverts, :name, :string
-    >>
+    => "remove_column :adverts, :title
+        add_column :adverts, :name, :string, limit: 255"
 
 When run as a generator, the migration-generator won't make this assumption. Instead it will prompt for user input to resolve the ambiguity. When using the Ruby API, we can ask for a rename instead of an add + drop by passing in a hash:
 
@@ -184,7 +181,7 @@ Let's apply that change to the database
     >> up.split(',').slice(0,3).join(',')
     => 'change_column :adverts, :title, :string'
     >> up.split(',').slice(3,2).sort.join(',')
-    => " :default => \"Untitled\""
+    => " :default => \"Untitled\", :limit => 255"
     >> down
     => "change_column :adverts, :title, :string, limit: 255"
 
@@ -201,8 +198,24 @@ Let's apply that change to the database
     >> up
     => "add_column :adverts, :price, :integer, :null => false, :limit => 2"
 
+Now run the migration, then change the limit:
+
+    >> ActiveRecord::Migration.class_eval up
+    >>
+     class Advert
+       fields do
+         price :integer, :limit => 3
+       end
+     end
+    >> up, down = Generators::Hobo::Migration::Migrator.run
+    >> up
+    => "change_column :adverts, :price, :integer, :limit => 3, :null => false"
+    >> down
+    => "change_column :adverts, :price, :integer, limit: 2, null: false"
+
 Note that limit on a decimal column is ignored (use :scale and :precision)
 
+    >> ActiveRecord::Migration.class_eval "remove_column :adverts, :price"
     >>
      class Advert
        fields do
@@ -297,7 +310,7 @@ TODO TECH-4814: The above test should have this output:
 TODO => "change_column :adverts, :description, :text, :limit => 255"
 
 
-And migrate to an stated text limit that is the same as the unstated one:
+And migrate to a stated text limit that is the same as the unstated one:
 
     >>
      class Advert
@@ -717,7 +730,7 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => {:title => :name})
     >> up
     => "rename_column :adverts, :title, :name
-        change_column :adverts, :name, :string, :default => \"No Name\""
+        change_column :adverts, :name, :string, :limit => 255, :default => \"No Name\""
     >> down
     => "rename_column :adverts, :name, :title
         change_column :adverts, :title, :string, limit: 255, default: \"Untitled\""
@@ -740,7 +753,7 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
     >> up.gsub(/\n+/, "\n")
     => "rename_table :adverts, :ads
         add_column :ads, :created_at, :datetime, :null => false
-        change_column :ads, :title, :string, :null => false, :default => \"Untitled\"
+        change_column :ads, :title, :string, :limit => 255, :null => false, :default => \"Untitled\"
         add_index :ads, [:id], :unique => true, :name => 'PRIMARY_KEY'"
 
     >>

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -278,6 +278,30 @@ Cleanup
     >> Advert.field_specs.delete :notes
 {.hidden}
 
+Limits that are too high will for MySQL will raise an exception.
+
+    >> ::HoboFields::Model::FieldSpec::instance_variable_set(:@mysql_text_limits, true)
+    >> ::HoboFields::Model::FieldSpec.mysql_text_limits?
+    => true
+    >>
+      begin
+        class Advert
+          fields do
+            notes :text
+            description :text, limit: 0x1_0000_0000
+          end
+        end
+      rescue => ex
+        "#{ex.class}: #{ex.message}"
+      end
+    => "ArgumentError: limit of 4294967296 is too large for MySQL"
+
+Cleanup
+{.hidden}
+
+    >> Advert.field_specs.delete :notes
+{.hidden}
+
 And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
 
 To start, we'll set the database schema for `description` to match the above limit of 255.

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -141,7 +141,7 @@ Here we rename the `name` field to `title`. By default the generator sees this a
 
 When run as a generator, the migration-generator won't make this assumption. Instead it will prompt for user input to resolve the ambiguity. When using the Ruby API, we can ask for a rename instead of an add + drop by passing in a hash:
 
-    >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => { :name => :title })
+    >> up, down = Generators::Hobo::Migration::Migrator.run(adverts: { name: :title })
     >> up
     => "rename_column :adverts, :name, :title"
     >> down
@@ -173,7 +173,7 @@ Let's apply that change to the database
     >>
      class Advert
        fields do
-         title :string, :default => "Untitled", limit: 255, null: true
+         title :string, default: "Untitled", limit: 255, null: true
          body :text, null: true
        end
      end
@@ -191,7 +191,7 @@ Let's apply that change to the database
     >>
      class Advert
        fields do
-         price :integer, :null => true, :limit => 2
+         price :integer, null: true, limit: 2
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -204,7 +204,7 @@ Now run the migration, then change the limit:
     >>
      class Advert
        fields do
-         price :integer, :null => true, :limit => 3
+         price :integer, null: true, limit: 3
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -219,7 +219,7 @@ Note that limit on a decimal column is ignored (use :scale and :precision)
     >>
      class Advert
        fields do
-         price :decimal, :null => true, :limit => 4
+         price :decimal, null: true, limit: 4
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -373,7 +373,7 @@ If you specify a custom foreign key, the migration generator observes that:
         >>
          class Category < ActiveRecord::Base; end
          class Advert
-           belongs_to :category, :foreign_key => "c_id", :class_name => 'Category'
+           belongs_to :category, foreign_key: "c_id", class_name: 'Category'
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
@@ -387,12 +387,12 @@ Cleanup:
         >> Advert.index_specs.delete_if { |spec| spec.fields==["c_id"] }
 {.hidden}
 
-You can avoid generating the index by specifying `:index => false`
+You can avoid generating the index by specifying `index: false`
 
         >>
          class Category < ActiveRecord::Base; end
          class Advert
-           belongs_to :category, :index => false
+           belongs_to :category, index: false
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
@@ -410,7 +410,7 @@ You can specify the index name with :index
         >>
          class Category < ActiveRecord::Base; end
          class Advert
-           belongs_to :category, :index => 'my_index'
+           belongs_to :category, index: 'my_index'
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up
@@ -464,7 +464,7 @@ You can add an index to a field definition
         >>
          class Advert
            fields do
-             title :string, :index => true, limit: 255, null: true
+             title :string, index: true, limit: 255, null: true
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -483,7 +483,7 @@ You can ask for a unique index
         >>
          class Advert
            fields do
-             title :string, :index => true, :unique => true, null: true, limit: 255
+             title :string, index: true, unique: true, null: true, limit: 255
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -502,7 +502,7 @@ You can specify the name for the index
         >>
          class Advert
            fields do
-             title :string, :index => 'my_index', limit: 255, null: true
+             title :string, index: 'my_index', limit: 255, null: true
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -537,7 +537,7 @@ The available options for the index function are `:unique` and `:name`
 
         >>
          class Advert
-           index :title, :unique => true, :name => 'my_index'
+           index :title, unique: true, name: 'my_index'
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
@@ -585,7 +585,7 @@ The migration generator respects the `set_table_name` declaration, although as b
     >> Advert.connection.schema_cache.clear!
     >> Advert.reset_column_information
 
-    >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :ads)
+    >> up, down = Generators::Hobo::Migration::Migrator.run("adverts" => "ads")
     >> up.gsub(/\n+/, "\n")
     => "rename_table :adverts, :ads
         add_column :ads, :title, :string, :limit => 255
@@ -628,7 +628,7 @@ As with renaming columns, we have to tell the migration generator about the rena
          body :text, null: true
        end
      end
-    >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :advertisements)
+    >> up, down = Generators::Hobo::Migration::Migrator.run("adverts" => "advertisements")
     >> up.gsub(/\n+/, "\n")
     => "rename_table :adverts, :advertisements
         add_column :advertisements, :title, :string, :limit => 255
@@ -671,7 +671,7 @@ Adding a subclass or two should introduce the 'type' column and no other changes
          class Advert < ActiveRecord::Base
            fields do
              body :text, null: true
-             title :string, :default => "Untitled", limit: 255, null: true
+             title :string, default: "Untitled", limit: 255, null: true
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -723,11 +723,11 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
     >>
      class Advert
        fields do
-         name :string, :default => "No Name", limit: 255, null: true
+         name :string, default: "No Name", limit: 255, null: true
          body :text, null: true
        end
      end
-    >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => {:title => :name})
+    >> up, down = Generators::Hobo::Migration::Migrator.run(adverts: { title: :name })
     >> up
     => "rename_column :adverts, :title, :name
         change_column :adverts, :name, :string, :limit => 255, :default => \"No Name\""
@@ -744,12 +744,12 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
     >>
      class Ad < ActiveRecord::Base
        fields do
-         title      :string, :default => "Untitled", limit: 255
+         title      :string, default: "Untitled", limit: 255
          body       :text, null: true
          created_at :datetime
        end
      end
-    >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :ads)
+    >> up, down = Generators::Hobo::Migration::Migrator.run(adverts: :ads)
     >> up.gsub(/\n+/, "\n")
     => "rename_table :adverts, :ads
         add_column :ads, :created_at, :datetime, :null => false
@@ -760,7 +760,7 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
      class Advert < ActiveRecord::Base
        fields do
          body :text, null: true
-         title :string, :default => "Untitled", limit: 255, null: true
+         title :string, default: "Untitled", limit: 255, null: true
        end
      end
 {.hidden}
@@ -777,7 +777,7 @@ HoboFields has some support for legacy keys.
        end
        self.primary_key="advert_id"
      end
-    >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => {:id => :advert_id})
+    >> up, down = Generators::Hobo::Migration::Migrator.run(adverts: { id: :advert_id })
     >> up.gsub(/\n+/, "\n")
     => "rename_column :adverts, :id, :advert_id
         add_index :adverts, [:advert_id], :unique => true, :name => 'PRIMARY_KEY'"
@@ -815,7 +815,7 @@ HoboFields can accept a validates hash in the field options.
     >>
       class Ad < ActiveRecord::Base
         fields do
-          company :string, limit: 255, index: true, unique: true, validates: { presence: true, :uniqueness => { case_sensitive: false } }
+          company :string, limit: 255, index: true, unique: true, validates: { presence: true, uniqueness: { case_sensitive: false } }
         end
         self.primary_key="advert_id"
       end

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -94,7 +94,7 @@ If we add a new field to the model, the migration generator will add it to the d
     >> up, down = migrate
     >> up
     =>
-     "add_column :adverts, :body, :text, limit: 0xffff * 3
+     "add_column :adverts, :body, :text, limit: 0xffff
      add_column :adverts, :published_at, :datetime"
     >> down
     =>
@@ -309,14 +309,16 @@ Cleanup:
         >> Advert.index_specs.delete_if {|spec| spec.fields==["category_id"]}
 {.hidden}
 
-### Timestamps
+### Timestamps and Optimimistic Locking
 
-`updated_at` and `created_at` can be declared with the shorthand `timestamps`
+`updated_at` and `created_at` can be declared with the shorthand `timestamps`.
+Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_lock`.
 
         >>
          class Advert
            fields do
              timestamps
+             optimistic_lock
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
@@ -335,6 +337,7 @@ Cleanup:
 
         >> Advert.field_specs.delete(:updated_at)
         >> Advert.field_specs.delete(:created_at)
+        >> Advert.field_specs.delete(:lock_version)
 {.hidden}
 
 ### Indices

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -652,11 +652,8 @@ Dropping tables is where the automatic down-migration really comes in handy:
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
     => "drop_table :adverts"
-    >> down.gsub(/^  /, '__')
-    => "create_table \"adverts\", id: :integer, force: :cascade do |t|
-        __t.string \"name\", limit: 255
-        __t.index [\"id\"], name: \"PRIMARY_KEY\", unique: true
-        end"
+    >> down.gsub(/,.*/m, '')
+    => "create_table \"adverts\""
 
 ## STI
 

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -133,7 +133,7 @@ Here we rename the `name` field to `title`. By default the generator sees this a
     >> # Just generate - don't run the migration:
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "add_column :adverts, :title, :string, :limit => 255
+    => "add_column :adverts, :title, :string, limit: 255
         remove_column :adverts, :name"
     >> down
     => "remove_column :adverts, :title
@@ -181,7 +181,7 @@ Let's apply that change to the database
     >> up.split(',').slice(0,3).join(',')
     => 'change_column :adverts, :title, :string'
     >> up.split(',').slice(3,2).sort.join(',')
-    => " :default => \"Untitled\", :limit => 255"
+    => " default: \"Untitled\", limit: 255"
     >> down
     => "change_column :adverts, :title, :string, limit: 255"
 
@@ -196,7 +196,7 @@ Let's apply that change to the database
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "add_column :adverts, :price, :integer, :limit => 2"
+    => "add_column :adverts, :price, :integer, limit: 2"
 
 Now run the migration, then change the limit:
 
@@ -209,7 +209,7 @@ Now run the migration, then change the limit:
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "change_column :adverts, :price, :integer, :limit => 3"
+    => "change_column :adverts, :price, :integer, limit: 3"
     >> down
     => "change_column :adverts, :price, :integer, limit: 2"
 
@@ -243,8 +243,8 @@ that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xfffff
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
     => "add_column :adverts, :price, :decimal
-        add_column :adverts, :notes, :text, :null => false
-        add_column :adverts, :description, :text, :null => false"
+        add_column :adverts, :notes, :text, null: false
+        add_column :adverts, :description, :text, null: false"
 
 (There is no limit on `add_column ... :description` above since these tests are run against SQLite.)
 
@@ -269,8 +269,8 @@ In MySQL, limits are applied, rounded up:
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "add_column :adverts, :notes, :text, :null => false
-        add_column :adverts, :description, :text, :null => false, :limit => 255"
+    => "add_column :adverts, :notes, :text, null: false
+        add_column :adverts, :description, :text, null: false, limit: 255"
 
 Cleanup
 {.hidden}
@@ -326,12 +326,12 @@ Now migrate to an unstated text limit:
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "change_column :adverts, :description, :text, :null => false"
+    => "change_column :adverts, :description, :text, null: false"
     >> down
     => "change_column :adverts, :description, :text"
 
 TODO TECH-4814: The above test should have this output:
-TODO => "change_column :adverts, :description, :text, :limit => 255"
+TODO => "change_column :adverts, :description, :text, limit: 255"
 
 
 And migrate to a stated text limit that is the same as the unstated one:
@@ -344,7 +344,7 @@ And migrate to a stated text limit that is the same as the unstated one:
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
-    => "change_column :adverts, :description, :text, :null => false"
+    => "change_column :adverts, :description, :text, null: false"
     >> down
     => "change_column :adverts, :description, :text"
     >> ::HoboFields::Model::FieldSpec::instance_variable_set(:@mysql_text_limits, false)
@@ -379,11 +379,11 @@ foreign-key field.  It also generates an index on the field.
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :category_id, :integer, :limit => 8, :null => false
-            add_index :adverts, [:category_id], :name => 'on_category_id'"
+        => "add_column :adverts, :category_id, :integer, limit: 8, null: false
+            add_index :adverts, [:category_id], name: 'on_category_id'"
         >> down.sub(/\n+/, "\n")
         => "remove_column :adverts, :category_id
-            remove_index :adverts, :name => :on_category_id rescue ActiveRecord::StatementInvalid"
+            remove_index :adverts, name: :on_category_id rescue ActiveRecord::StatementInvalid"
 
 Cleanup:
 {.hidden}
@@ -401,8 +401,8 @@ If you specify a custom foreign key, the migration generator observes that:
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :c_id, :integer, :limit => 8, :null => false
-            add_index :adverts, [:c_id], :name => 'on_c_id'"
+        => "add_column :adverts, :c_id, :integer, limit: 8, null: false
+            add_index :adverts, [:c_id], name: 'on_c_id'"
 
 Cleanup:
 {.hidden}
@@ -420,7 +420,7 @@ You can avoid generating the index by specifying `index: false`
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :category_id, :integer, :limit => 8, :null => false"
+        => "add_column :adverts, :category_id, :integer, limit: 8, null: false"
 
 Cleanup:
 {.hidden}
@@ -438,8 +438,8 @@ You can specify the index name with :index
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :category_id, :integer, :limit => 8, :null => false
-            add_index :adverts, [:category_id], :name => 'my_index'"
+        => "add_column :adverts, :category_id, :integer, limit: 8, null: false
+            add_index :adverts, [:category_id], name: 'my_index'"
 
 Cleanup:
 {.hidden}
@@ -464,7 +464,7 @@ Similarly, `lock_version` can be declared with the "shorthand" `optimimistic_loc
         >> up.gsub(/\n+/, "\n")
         => "add_column :adverts, :created_at, :datetime
             add_column :adverts, :updated_at, :datetime
-            add_column :adverts, :lock_version, :integer, :null => false, :default => 1"
+            add_column :adverts, :lock_version, :integer, null: false, default: 1"
         >> down.gsub(/\n+/, "\n")
         => "remove_column :adverts, :created_at
             remove_column :adverts, :updated_at
@@ -491,8 +491,8 @@ You can add an index to a field definition
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :title, :string, :limit => 255
-            add_index :adverts, [:title], :name => 'on_title'"
+        => "add_column :adverts, :title, :string, limit: 255
+            add_index :adverts, [:title], name: 'on_title'"
 
 Cleanup:
 {.hidden}
@@ -510,8 +510,8 @@ You can ask for a unique index
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :title, :string, :limit => 255
-            add_index :adverts, [:title], :unique => true, :name => 'on_title'"
+        => "add_column :adverts, :title, :string, limit: 255
+            add_index :adverts, [:title], unique: true, name: 'on_title'"
 
 Cleanup:
 {.hidden}
@@ -529,8 +529,8 @@ You can specify the name for the index
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :title, :string, :limit => 255
-            add_index :adverts, [:title], :name => 'my_index'"
+        => "add_column :adverts, :title, :string, limit: 255
+            add_index :adverts, [:title], name: 'my_index'"
 
 Cleanup:
 {.hidden}
@@ -546,8 +546,8 @@ You can ask for an index outside of the fields block
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :title, :string, :limit => 255
-            add_index :adverts, [:title], :name => 'on_title'"
+        => "add_column :adverts, :title, :string, limit: 255
+            add_index :adverts, [:title], name: 'on_title'"
 
 Cleanup:
 {.hidden}
@@ -563,8 +563,8 @@ The available options for the index function are `:unique` and `:name`
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :title, :string, :limit => 255
-            add_index :adverts, [:title], :unique => true, :name => 'my_index'"
+        => "add_column :adverts, :title, :string, limit: 255
+            add_index :adverts, [:title], unique: true, name: 'my_index'"
 
 Cleanup:
 {.hidden}
@@ -580,8 +580,8 @@ You can create an index on more than one field
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :title, :string, :limit => 255
-            add_index :adverts, [:title, :category_id], :name => 'on_title_and_category_id'"
+        => "add_column :adverts, :title, :string, limit: 255
+            add_index :adverts, [:title, :category_id], name: 'on_title_and_category_id'"
 
 Cleanup:
 {.hidden}
@@ -610,14 +610,14 @@ The migration generator respects the `set_table_name` declaration, although as b
     >> up, down = Generators::Hobo::Migration::Migrator.run("adverts" => "ads")
     >> up.gsub(/\n+/, "\n")
     => "rename_table :adverts, :ads
-        add_column :ads, :title, :string, :limit => 255
+        add_column :ads, :title, :string, limit: 255
         add_column :ads, :body, :text
-        add_index :ads, [:id], :unique => true, :name => 'PRIMARY_KEY'"
+        add_index :ads, [:id], unique: true, name: 'PRIMARY_KEY'"
     >> down.gsub(/\n+/, "\n")
     => "remove_column :ads, :title
         remove_column :ads, :body
         rename_table :ads, :adverts
-        add_index :adverts, [:id], :unique => true, :name => 'PRIMARY_KEY'"
+        add_index :adverts, [:id], unique: true, name: 'PRIMARY_KEY'"
 
 Set the table name back to what it should be and confirm we're in sync:
 
@@ -653,16 +653,16 @@ As with renaming columns, we have to tell the migration generator about the rena
     >> up, down = Generators::Hobo::Migration::Migrator.run("adverts" => "advertisements")
     >> up.gsub(/\n+/, "\n")
     => "rename_table :adverts, :advertisements
-        add_column :advertisements, :title, :string, :limit => 255
+        add_column :advertisements, :title, :string, limit: 255
         add_column :advertisements, :body, :text
         remove_column :advertisements, :name
-        add_index :advertisements, [:id], :unique => true, :name => 'PRIMARY_KEY'"
+        add_index :advertisements, [:id], unique: true, name: 'PRIMARY_KEY'"
     >> down.gsub(/\n+/, "\n")
     => "remove_column :advertisements, :title
         remove_column :advertisements, :body
         add_column :adverts, :name, :string, limit: 255
         rename_table :advertisements, :adverts
-        add_index :adverts, [:id], :unique => true, :name => 'PRIMARY_KEY'"
+        add_index :adverts, [:id], unique: true, name: 'PRIMARY_KEY'"
 
 ### Drop a table
 
@@ -701,11 +701,11 @@ Adding a subclass or two should introduce the 'type' column and no other changes
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
         >> up.gsub(/\n+/, "\n")
-        => "add_column :adverts, :type, :string, :limit => 255
-            add_index :adverts, [:type], :name => 'on_type'"
+        => "add_column :adverts, :type, :string, limit: 255
+            add_index :adverts, [:type], name: 'on_type'"
         >> down.gsub(/\n+/, "\n")
         => "remove_column :adverts, :type
-            remove_index :adverts, :name => :on_type rescue ActiveRecord::StatementInvalid"
+            remove_index :adverts, name: :on_type rescue ActiveRecord::StatementInvalid"
 
 Cleanup
 {.hidden}
@@ -748,7 +748,7 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
     >> up, down = Generators::Hobo::Migration::Migrator.run(adverts: { title: :name })
     >> up
     => "rename_column :adverts, :title, :name
-        change_column :adverts, :name, :string, :limit => 255, :default => \"No Name\""
+        change_column :adverts, :name, :string, limit: 255, default: \"No Name\""
     >> down
     => "rename_column :adverts, :name, :title
         change_column :adverts, :title, :string, limit: 255, default: \"Untitled\""
@@ -770,9 +770,9 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
     >> up, down = Generators::Hobo::Migration::Migrator.run(adverts: :ads)
     >> up.gsub(/\n+/, "\n")
     => "rename_table :adverts, :ads
-        add_column :ads, :created_at, :datetime, :null => false
-        change_column :ads, :title, :string, :limit => 255, :null => false, :default => \"Untitled\"
-        add_index :ads, [:id], :unique => true, :name => 'PRIMARY_KEY'"
+        add_column :ads, :created_at, :datetime, null: false
+        change_column :ads, :title, :string, limit: 255, null: false, default: \"Untitled\"
+        add_index :ads, [:id], unique: true, name: 'PRIMARY_KEY'"
 
     >>
      class Advert < ActiveRecord::Base
@@ -798,7 +798,7 @@ HoboFields has some support for legacy keys.
     >> up, down = Generators::Hobo::Migration::Migrator.run(adverts: { id: :advert_id })
     >> up.gsub(/\n+/, "\n")
     => "rename_column :adverts, :id, :advert_id
-        add_index :adverts, [:advert_id], :unique => true, :name => 'PRIMARY_KEY'"
+        add_index :adverts, [:advert_id], unique: true, name: 'PRIMARY_KEY'"
 
     >> nuke_model_class(Advert)
     >> ActiveRecord::Base.connection.execute "drop table `adverts`;"

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -251,21 +251,82 @@ In MySQL, limits are applied, rounded up:
      class Advert
        fields do
          notes :text
-         description :text, limit: 30000
+         description :text, limit: 200
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run
     >> up
     => "add_column :adverts, :notes, :text, :null => false
-        add_column :adverts, :description, :text, :null => false, :limit => 65535"
-    >> ::HoboFields::Model::FieldSpec::instance_variable_set(:@mysql_text_limits, false)
-
+        add_column :adverts, :description, :text, :null => false, :limit => 255"
 
 Cleanup
 {.hidden}
 
-    >> Advert.field_specs.delete :price
     >> Advert.field_specs.delete :notes
+{.hidden}
+
+And in MySQL, unstated text limits are treated as the maximum (LONGTEXT) limit.
+
+To start, we'll set the database schema for `description` to match the above limit of 255.
+
+    >> ::HoboFields::Model::FieldSpec.mysql_text_limits?
+    => true
+    >> Advert.connection.execute "ALTER TABLE adverts ADD COLUMN description TINYTEXT"
+    >> Advert.connection.schema_cache.clear!
+    >> Advert.reset_column_information
+    >> Advert.connection.tables
+    => ["adverts"]
+    >> Advert.columns.map(&:name)
+    => ["id", "body", "title", "description"]
+
+Now migrate to an unstated text limit:
+
+    >>
+     class Advert
+       fields do
+         description :text
+       end
+     end
+    >> up, down = Generators::Hobo::Migration::Migrator.run
+    >> up
+    => "change_column :adverts, :description, :text, :null => false"
+    >> down
+    => "change_column :adverts, :description, :text"
+
+TODO TECH-4814: The above test should have this output:
+TODO => "change_column :adverts, :description, :text, :limit => 255"
+
+
+And migrate to an stated text limit that is the same as the unstated one:
+
+    >>
+     class Advert
+       fields do
+         description :text, limit: 0xffffffff
+       end
+     end
+    >> up, down = Generators::Hobo::Migration::Migrator.run
+    >> up
+    => "change_column :adverts, :description, :text, :null => false"
+    >> down
+    => "change_column :adverts, :description, :text"
+    >> ::HoboFields::Model::FieldSpec::instance_variable_set(:@mysql_text_limits, false)
+
+Cleanup
+{.hidden}
+    >> Advert.field_specs.clear
+    >> Advert.connection.schema_cache.clear!
+    >> Advert.reset_column_information
+    >>
+     class Advert < ActiveRecord::Base
+       fields do
+         name :string, limit: 255, null: true
+       end
+     end
+    >> up, down = Generators::Hobo::Migration::Migrator.run
+    >> ActiveRecord::Migration.class_eval up
+    >> Advert.connection.schema_cache.clear!
+    >> Advert.reset_column_information
 {.hidden}
 
 
@@ -280,16 +341,12 @@ foreign-key field.  It also generates an index on the field.
            belongs_to :category
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up
-        =>
-         "add_column :adverts, :category_id, :integer
-
-         add_index :adverts, [:category_id]"
-        >> down
-        =>
-         "remove_column :adverts, :category_id
-
-         remove_index :adverts, :name => :index_adverts_on_category_id rescue ActiveRecord::StatementInvalid"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :category_id, :integer, :limit => 8, :null => false
+            add_index :adverts, [:category_id], :name => 'on_category_id'"
+        >> down.sub(/\n+/, "\n")
+        => "remove_column :adverts, :category_id
+            remove_index :adverts, :name => :on_category_id rescue ActiveRecord::StatementInvalid"
 
 Cleanup:
 {.hidden}
@@ -306,17 +363,14 @@ If you specify a custom foreign key, the migration generator observes that:
            belongs_to :category, :foreign_key => "c_id", :class_name => 'Category'
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up
-        =>
-         "add_column :adverts, :c_id, :integer
-
-         add_index :adverts, [:c_id]"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :c_id, :integer, :limit => 8, :null => false
+            add_index :adverts, [:c_id], :name => 'on_c_id'"
 
 Cleanup:
 {.hidden}
 
         >> Advert.field_specs.delete(:c_id)
-        >> Advert.field_specs.delete(:description)
         >> Advert.index_specs.delete_if { |spec| spec.fields==["c_id"] }
 {.hidden}
 
@@ -328,7 +382,7 @@ You can avoid generating the index by specifying `:index => false`
            belongs_to :category, :index => false
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up
+        >> up.gsub(/\n+/, "\n")
         => "add_column :adverts, :category_id, :integer, :limit => 8, :null => false"
 
 Cleanup:
@@ -401,13 +455,14 @@ You can add an index to a field definition
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up.split("\n")[2]
-        => "add_index :adverts, [:title], :name => 'on_title'"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :title, :string, :limit => 255
+            add_index :adverts, [:title], :name => 'on_title'"
 
 Cleanup:
 {.hidden}
 
-        >> Advert.index_specs.delete_if {|spec| spec.fields==["title"]}
+        >> Advert.index_specs.delete_if { |spec| spec.fields==["title"] }
 {.hidden}
 
 You can ask for a unique index
@@ -419,13 +474,14 @@ You can ask for a unique index
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up.split("\n")[2]
-        => "add_index :adverts, [:title], :unique => true, :name => 'on_title'"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :title, :string, :limit => 255
+            add_index :adverts, [:title], :unique => true, :name => 'on_title'"
 
 Cleanup:
 {.hidden}
 
-        >> Advert.index_specs.delete_if {|spec| spec.fields==["title"]}
+        >> Advert.index_specs.delete_if { |spec| spec.fields==["title"] }
 {.hidden}
 
 You can specify the name for the index
@@ -437,8 +493,9 @@ You can specify the name for the index
            end
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up.split("\n")[2]
-        => "add_index :adverts, [:title], :name => 'my_index'"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :title, :string, :limit => 255
+            add_index :adverts, [:title], :name => 'my_index'"
 
 Cleanup:
 {.hidden}
@@ -453,13 +510,14 @@ You can ask for an index outside of the fields block
            index :title
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up.split("\n")[2]
-        => "add_index :adverts, [:title], :name => 'on_title'"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :title, :string, :limit => 255
+            add_index :adverts, [:title], :name => 'on_title'"
 
 Cleanup:
 {.hidden}
 
-        >> Advert.index_specs.delete_if {|spec| spec.fields==["title"]}
+        >> Advert.index_specs.delete_if { |spec| spec.fields==["title"] }
 {.hidden}
 
 The available options for the index function are `:unique` and `:name`
@@ -469,8 +527,9 @@ The available options for the index function are `:unique` and `:name`
            index :title, :unique => true, :name => 'my_index'
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up.split("\n")[2]
-        => "add_index :adverts, [:title], :unique => true, :name => 'my_index'"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :title, :string, :limit => 255
+            add_index :adverts, [:title], :unique => true, :name => 'my_index'"
 
 Cleanup:
 {.hidden}
@@ -485,13 +544,14 @@ You can create an index on more than one field
            index [:title, :category_id]
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up.split("\n")[2]
-        => "add_index :adverts, [:title, :category_id], :name => 'on_title_and_category_id'"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :title, :string, :limit => 255
+            add_index :adverts, [:title, :category_id], :name => 'on_title_and_category_id'"
 
 Cleanup:
 {.hidden}
 
-        >> Advert.index_specs.delete_if {|spec| spec.fields==["title", "category_id"]}
+        >> Advert.index_specs.delete_if { |spec| spec.fields==["title", "category_id"] }
 {.hidden}
 
 Finally, you can specify that the migration generator should completely ignore an index by passing its name to ignore_index in the model. This is helpful for preserving indices that can't be automatically generated, such as prefix indices in MySQL.
@@ -504,18 +564,30 @@ The migration generator respects the `set_table_name` declaration, although as b
      class Advert
        self.table_name="ads"
        fields do
-         title :string, :default => "Untitled", limit: 255, null: true
+         title :string, limit: 255, null: true
          body :text, null: true
        end
      end
+
+    >> Advert.connection.schema_cache.clear!
+    >> Advert.reset_column_information
+
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :ads)
-    >> up.split("\n")[0]
-    => "rename_table :adverts, :ads"
-    >> down.split("\n")[0]
-    => "rename_table :ads, :adverts"
+    >> up.gsub(/\n+/, "\n")
+    => "rename_table :adverts, :ads
+        add_column :ads, :title, :string, :limit => 255
+        add_column :ads, :body, :text
+        add_index :ads, [:id], :unique => true, :name => 'PRIMARY_KEY'"
+    >> down.gsub(/\n+/, "\n")
+    => "remove_column :ads, :title
+        remove_column :ads, :body
+        rename_table :ads, :adverts
+        add_index :adverts, [:id], :unique => true, :name => 'PRIMARY_KEY'"
 
 Set the table name back to what it should be and confirm we're in sync:
 
+    >> Advert.field_specs.delete(:title)
+    >> Advert.field_specs.delete(:body)
     >> class Advert; self.table_name="adverts"; end
     >> Generators::Hobo::Migration::Migrator.run
     => ["", ""]
@@ -539,15 +611,23 @@ As with renaming columns, we have to tell the migration generator about the rena
     >>
      class Advertisement < ActiveRecord::Base
        fields do
-         title :string, :default => "Untitled", limit: 255, null: true
+         title :string, limit: 255, null: true
          body :text, null: true
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :advertisements)
-    >> up.split("\n")[0]
-    => "rename_table :adverts, :advertisements"
-    >> down.split("\n")[0]
-    => "rename_table :advertisements, :adverts"
+    >> up.gsub(/\n+/, "\n")
+    => "rename_table :adverts, :advertisements
+        add_column :advertisements, :title, :string, :limit => 255
+        add_column :advertisements, :body, :text
+        remove_column :advertisements, :name
+        add_index :advertisements, [:id], :unique => true, :name => 'PRIMARY_KEY'"
+    >> down.gsub(/\n+/, "\n")
+    => "remove_column :advertisements, :title
+        remove_column :advertisements, :body
+        add_column :adverts, :name, :string, limit: 255
+        rename_table :advertisements, :adverts
+        add_index :adverts, [:id], :unique => true, :name => 'PRIMARY_KEY'"
 
 ### Drop a table
 
@@ -581,21 +661,20 @@ Adding a subclass or two should introduce the 'type' column and no other changes
              title :string, :default => "Untitled", limit: 255, null: true
            end
          end
+        >> up, down = Generators::Hobo::Migration::Migrator.run
+        >> ActiveRecord::Migration.class_eval up
+
          class FancyAdvert < Advert
          end
          class SuperFancyAdvert < FancyAdvert
          end
         >> up, down = Generators::Hobo::Migration::Migrator.run
-        >> up
-        =>
-         "add_column :adverts, :type, :string
-
-         add_index :adverts, [:type]"
-        >> down
-        =>
-         "remove_column :adverts, :type
-
-         remove_index :adverts, :name => :index_adverts_on_type rescue ActiveRecord::StatementInvalid"
+        >> up.gsub(/\n+/, "\n")
+        => "add_column :adverts, :type, :string, :limit => 255
+            add_index :adverts, [:type], :name => 'on_type'"
+        >> down.gsub(/\n+/, "\n")
+        => "remove_column :adverts, :type
+            remove_index :adverts, :name => :on_type rescue ActiveRecord::StatementInvalid"
 
 Cleanup
 {.hidden}
@@ -603,7 +682,7 @@ Cleanup
         >> Advert.field_specs.delete(:type)
         >> nuke_model_class(SuperFancyAdvert)
         >> nuke_model_class(FancyAdvert)
-        >> Advert.index_specs.delete_if {|spec| spec.fields==["type"]}
+        >> Advert.index_specs.delete_if { |spec| spec.fields==["type"] }
 {.hidden}
 
 
@@ -613,12 +692,14 @@ The migration generator is designed to create complete migrations even if many c
 
 First let's confirm we're in a known state. One model, 'Advert', with a string 'title' and text 'body':
 
+    >> ActiveRecord::Migration.class_eval up.gsub(/.*type.*/, '')
     >> Advert.connection.schema_cache.clear!
     >> Advert.reset_column_information
+
     >> Advert.connection.tables
     => ["adverts"]
-    >> Advert.columns.*.name
-    => ["id", "body", "title"]
+    >> Advert.columns.map(&:name).sort
+    => ["body", "id", "title"]
     >> Generators::Hobo::Migration::Migrator.run
     => ["", ""]
 
@@ -635,13 +716,11 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => {:title => :name})
     >> up
-    =>
-     "rename_column :adverts, :title, :name
-     change_column :adverts, :name, :string, :default => "No Name", :limit => 255"
+    => "rename_column :adverts, :title, :name
+        change_column :adverts, :name, :string, :default => \"No Name\""
     >> down
-    =>
-     'rename_column :adverts, :name, :title
-     change_column :adverts, :title, :string, :default => "Untitled"'
+    => "rename_column :adverts, :name, :title
+        change_column :adverts, :title, :string, limit: 255, default: \"Untitled\""
 
 
 ### Rename a table and add a column
@@ -658,11 +737,11 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => :ads)
-    >> up
-    =>
-     "rename_table :adverts, :ads
-
-     add_column :ads, :created_at, :datetime"
+    >> up.gsub(/\n+/, "\n")
+    => "rename_table :adverts, :ads
+        add_column :ads, :created_at, :datetime, :null => false
+        change_column :ads, :title, :string, :null => false, :default => \"Untitled\"
+        add_index :ads, [:id], :unique => true, :name => 'PRIMARY_KEY'"
 
     >>
      class Advert < ActiveRecord::Base
@@ -677,22 +756,20 @@ First let's confirm we're in a known state. One model, 'Advert', with a string '
 
 HoboFields has some support for legacy keys.
 
-    >> Advert.field_specs.clear
+    >> nuke_model_class(Ad)
     >>
-     class Advert
+     class Advert < ActiveRecord::Base
        fields do
-         name :string, :default => "No Name", limit: 255, null: true
          body :text, null: true
        end
        self.primary_key="advert_id"
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run(:adverts => {:id => :advert_id})
-    >> up
-    =>
-     "rename_column :adverts, :id, :advert_id
+    >> up.gsub(/\n+/, "\n")
+    => "rename_column :adverts, :id, :advert_id
+        add_index :adverts, [:advert_id], :unique => true, :name => 'PRIMARY_KEY'"
 
     >> nuke_model_class(Advert)
-    >> nuke_model_class(Ad)
     >> ActiveRecord::Base.connection.execute "drop table `adverts`;"
 {.hidden}
 
@@ -703,13 +780,13 @@ The DSL allows lambdas and constants
     >>
         class User < ActiveRecord::Base
           fields do
-            company :string, limit: 255, ruby_default: lambda { Hash.name }
+            company :string, limit: 255, ruby_default: -> { "BigCorp" }
           end
         end
     >> User.field_specs.keys
     => ['company']
     >> User.field_specs['company'].options[:ruby_default]&.call
-    => "Hash"
+    => "BigCorp"
 
 
 ## validates

--- a/test/migration_generator.rdoctest
+++ b/test/migration_generator.rdoctest
@@ -218,6 +218,8 @@ allowed for that database type (0xffffffff for LONGTEXT in MySQL unlimited in Po
 If a `limit` is given, it will only be used in MySQL, to choose the smallest TEXT field that will accommodate
 that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xffffffff for LONGTEXT).
 
+    >> ::HoboFields::Model::FieldSpec.mysql_text_limits?
+    => false
     >>
      class Advert
        fields do
@@ -231,7 +233,33 @@ that limit (0xff for TINYTEXT, 0xffff for TEXT, 0xffffff for MEDIUMTEXT, 0xfffff
         add_column :adverts, :notes, :text, :null => false
         add_column :adverts, :description, :text, :null => false"
 
-(No limit on `add_column ... :description` above since these tests are run against SQLite.)
+(There is no limit on `add_column ... :description` above since these tests are run against SQLite.)
+
+Cleanup
+{.hidden}
+    >> Advert.field_specs.delete :price
+    >> Advert.field_specs.delete :notes
+    >> Advert.field_specs.delete :description
+{.hidden}
+
+In MySQL, limits are applied, rounded up:
+
+    >> ::HoboFields::Model::FieldSpec::instance_variable_set(:@mysql_text_limits, true)
+    >> ::HoboFields::Model::FieldSpec.mysql_text_limits?
+    => true
+    >>
+     class Advert
+       fields do
+         notes :text
+         description :text, limit: 30000
+       end
+     end
+    >> up, down = Generators::Hobo::Migration::Migrator.run
+    >> up
+    => "add_column :adverts, :notes, :text, :null => false
+        add_column :adverts, :description, :text, :null => false, :limit => 65535"
+    >> ::HoboFields::Model::FieldSpec::instance_variable_set(:@mysql_text_limits, false)
+
 
 Cleanup
 {.hidden}

--- a/test/migration_generator_comments.rdoctestDISABLED
+++ b/test/migration_generator_comments.rdoctestDISABLED
@@ -27,7 +27,7 @@ Comments can be added to tables and fields with HoboFields.
     >>
      class Product < ActiveRecord::Base
        fields do
-         name :string, :comment => "short name"
+         name :string, comment: "short name"
          description :string
        end
      end
@@ -54,8 +54,8 @@ Because it will be quite common for people not to have both [column_comments](ht
     >>
      class Product < ActiveRecord::Base
        fields do
-         name :string, :comment => "Short namex"
-         description :string, :comment => "Long name"
+         name :string, comment: "Short namex"
+         description :string, comment: "Long name"
        end
      end
     >> up, down = Generators::Hobo::Migration::Migrator.run


### PR DESCRIPTION
## [3.2.0] - Unreleased
### Changed
- Removed automatic scaling of `:text :limit` by UTF8_BYTES_PER_CHAR = 3.

### Added
- When using MySQL, `:text :limit` is now rounded up to nearest supported size, with a default of the max (LONGTEXT) size, 0xffff_ffff. For other databases, `:text :limit` is ignored.