### PR TITLE
TECH-4816: ignore ar_internal_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2020-09-29
+### Added
+- Added the Rails 5 internal table `ar_internal_metadata` to the `always_ignore_tables` list.
+
+
 ## [4.0.0] - 2020-09-11
 ### Changed
 - Removed automatic scaling of `:text :limit` by / UTF8_BYTES_PER_CHAR = 3.
@@ -23,5 +28,6 @@ For other databases, `:text :limit` is ignored.
 ### Removed
 - Removed support for rich type classes like `Markdown` and `HTML` text fields
 
+[4.1.0]: https://github.com/Invoca/hobo_fields/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/Invoca/hobo_fields/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/Invoca/pnapi_models/tree/v3.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hobo_fields (4.0.0)
+    hobo_fields (4.1.0)
       invoca-utils (~> 0.4)
       rails (>= 4.2, < 7)
 

--- a/lib/generators/hobo/migration/migrator.rb
+++ b/lib/generators/hobo/migration/migrator.rb
@@ -217,12 +217,18 @@ module Generators
 
 
         def always_ignore_tables
-          # TODO: figure out how to do this in a sane way and be compatible with 2.2 and 2.3 - class has moved
-          sessions_table = CGI::Session::ActiveRecordStore::Session.table_name if
-            defined?(CGI::Session::ActiveRecordStore::Session) &&
-            defined?(ActionController::Base) &&
-            ActionController::Base.session_store == CGI::Session::ActiveRecordStore
-          ['schema_info', 'schema_migrations',  'simple_sesions'].compact
+          sessions_table =
+            begin
+              if defined?(CGI::Session::ActiveRecordStore::Session) &&
+                 defined?(ActionController::Base) &&
+                 ActionController::Base.session_store == CGI::Session::ActiveRecordStore
+                CGI::Session::ActiveRecordStore::Session.table_name
+              end
+            rescue
+              nil
+            end
+
+          ['schema_info', 'schema_migrations', 'ar_internal_metadata', sessions_table].compact
         end
 
 

--- a/lib/hobo_fields/version.rb
+++ b/lib/hobo_fields/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HoboFields
-  VERSION = "4.0.0"
+  VERSION = "4.1.0"
 end


### PR DESCRIPTION
- Included `ar_internal_metadata` in `always_ignore_tables`.
- Fixed merge bug in existing code that `sessions_table` wasn't being included in the array any more. Also added a `rescue` just in case the attempt to get that table name fails.